### PR TITLE
fix(orders): order routes fixed

### DIFF
--- a/components/orders/routes.js
+++ b/components/orders/routes.js
@@ -60,7 +60,7 @@ function ordersApi(app) {
           const patient = await usersService.getUserId({
             userId: order.patientId,
           });
-          const result = order.isComplete ? await resultService.getResults(order.resultId) : {};
+          const result = order.isComplete ? await resultService.getResult(order.resultId) : {};
           const bacteriologist = order.isComplete ? await usersService.getUserId({ userId: result.bacteriologistId }) : {};
 
           return ({


### PR DESCRIPTION
order routes call `resultService.getResults`, but the correct name is `resultService.getResult`

refs: #83